### PR TITLE
Added exception handling for exchanges that don't support timeframes

### DIFF
--- a/app/behaviour.py
+++ b/app/behaviour.py
@@ -118,6 +118,12 @@ class Behaviour():
                         market_pair
                     )
                     self.logger.debug(traceback.format_exc())
+                except AttributeError:
+                    self.logger.info(
+                        'Something went wrong fetching data for %s, skippping',
+                        market_pair
+                    )
+                    self.logger.debug(traceback.format_exc())
                 except RetryError:
                     self.logger.info(
                         'Too many retries fetching informationg for pair %s, skipping',

--- a/app/exchange.py
+++ b/app/exchange.py
@@ -2,6 +2,7 @@
 """
 
 import re
+import sys
 import time
 from datetime import datetime, timedelta, timezone
 
@@ -56,14 +57,21 @@ class ExchangeInterface():
             list: Contains a list of lists which contain timestamp, open, high, low, close, volume.
         """
 
-        if time_unit not in self.exchanges[exchange].timeframes:
-            raise ValueError(
-                "{} does not support {} timeframe for OHLCV data. Possible values are: {}".format(
-                    exchange,
-                    time_unit,
-                    list(self.exchanges[exchange].timeframes)
+        try:
+            if time_unit not in self.exchanges[exchange].timeframes:
+                raise ValueError(
+                    "{} does not support {} timeframe for OHLCV data. Possible values are: {}".format(
+                        exchange,
+                        time_unit,
+                        list(self.exchanges[exchange].timeframes)
+                    )
                 )
+        except AttributeError:
+            self.logger.info(
+                '%s interface does not support timeframe queries! We are unable to fetch data!',
+                exchange
             )
+            raise AttributeError(sys.exc_info())
 
         if not start_date:
             timeframe_regex = re.compile('([0-9]+)([a-zA-Z])')


### PR DESCRIPTION
Some exchanges don't support timeframe querying of candle data. This will result in a more meaningful error message.