### PR TITLE
Fix traceback message on exit

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@
 """
 
 import time
+import sys
 
 import logs
 import conf
@@ -43,4 +44,7 @@ def main():
         time.sleep(settings['update_interval'])
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)


### PR DESCRIPTION
This is just a UX change to remove the traceback message when exiting the app. Makes it neater for OCD people like myself 🙂

I've tested it by rebuilding the container with the new `app.py` and running it myself.

Before:
```
Sleeping for 3600 seconds
^CTraceback (most recent call last):
  File "app.py", line 46, in <module>
    main()
  File "app.py", line 43, in main
    time.sleep(settings['update_interval'])
KeyboardInterrupt
```

After:
```
Sleeping for 3600 seconds
^C%
```