### PR TITLE
amend docker run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The commands listed below are intended to be run in a terminal.
 
 1. Create a config.yml file in your current directory. See the Configuring config.yml section below for customizing settings.
 
-1. In a terminal run the application. `docker run --rm -v ./config.yml:/app/config.yml shadowreaver/crypto-signal:master`.
+1. In a terminal run the application. `docker run --rm -v $(pwd)/config.yml:/app/config.yml shadowreaver/crypto-signal:master`.
 
 1. When you want to update the application run `docker pull shadowreaver/crypto-signal:master`
 


### PR DESCRIPTION
Running `docker run` with relative paths (unless running `docker-compose up`) results in this error:

```
docker run --rm -v ./config.yml:/app/config.yml shadowreaver/crypto-signal:master
docker: Error response from daemon: create ./config.yml: "./config.yml" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

I changed the README to use the absolute path, as that works on my machine (macOS) and my Ubuntu VPS.