### PR TITLE
Fix "alert_frequency: once" logic

### DIFF
--- a/app/notification.py
+++ b/app/notification.py
@@ -278,6 +278,9 @@ class Notifier():
                             elif latest_result['is_cold']:
                                 status = 'cold'
 
+                            # Save status of indicator's new analysis
+                            new_analysis[exchange][market][indicator_type][indicator][index]['status'] = status
+
                             if latest_result['is_hot'] or latest_result['is_cold']:
                                 try:
                                     last_status = self.last_analysis[exchange][market][indicator_type][indicator][index]['status']
@@ -293,7 +296,6 @@ class Notifier():
                                     should_alert = False
 
                                 if should_alert:
-                                    new_analysis[exchange][market][indicator_type][indicator][index]['status'] = status
                                     new_message += message_template.render(
                                         values=values,
                                         exchange=exchange,


### PR DESCRIPTION
I noticed an issue when using the app with the `alert_frequency` settings turned to `once` which is default.

It actually alerts every second time, as it's unable to get a value for `last_status` (which is set to a `str()` if it can't find `self.last_analysis[exchange][market][indicator_type][indicator][index]['status']`).

I tested this fix on my fork and it fixes the issue - please check if I've missed anything there.