### PR TITLE
add options for Base Currency and Quote Currency

### DIFF
--- a/app/notification.py
+++ b/app/notification.py
@@ -324,6 +324,8 @@ class Notifier():
                                         values=values,
                                         exchange=exchange,
                                         market=market,
+                                        market_from=market.split("/")[0],
+                                        market_to=market.split("/")[1],
                                         indicator=indicator,
                                         indicator_number=index,
                                         analysis=analysis,

--- a/app/notification.py
+++ b/app/notification.py
@@ -320,12 +320,13 @@ class Notifier():
                                     should_alert = False
 
                                 if should_alert:
+                                    base_currency, quote_currency = market.split('/')
                                     new_message += message_template.render(
                                         values=values,
                                         exchange=exchange,
                                         market=market,
-                                        market_from=market.split("/")[0],
-                                        market_to=market.split("/")[1],
+                                        base_currency=base_currency,
+                                        quote_currency=quote_currency,
                                         indicator=indicator,
                                         indicator_number=index,
                                         analysis=analysis,

--- a/docs/config.md
+++ b/docs/config.md
@@ -304,8 +304,8 @@ The notifier templates are built with a templating language called [Jinja2](http
 
 - exchange - The name of the exchange for the indicator.
 - market - The name of the market for the indicator.
-- market_from - The name of the base currency. If the market is BTC/USD, then this value is BTC.
-- market_to - The name of the quote currency. If the market is BTC/USD, then this value is USD.
+- base_currency - The name of the base currency. If the market is BTC/USD, then this value is BTC.
+- quote_currency - The name of the quote currency. If the market is BTC/USD, then this value is USD.
 - indicator - The name of the analyzer used for this indicator.
 - indicator_number - Which configured instance of the analyzer this indicator applies too.
 - status - Whether the indicator is hot, cold or neutral.

--- a/docs/config.md
+++ b/docs/config.md
@@ -304,6 +304,8 @@ The notifier templates are built with a templating language called [Jinja2](http
 
 - exchange - The name of the exchange for the indicator.
 - market - The name of the market for the indicator.
+- market_from - The name of the base currency. If the market is BTC/USD, then this value is BTC.
+- market_to - The name of the quote currency. If the market is BTC/USD, then this value is USD.
 - indicator - The name of the analyzer used for this indicator.
 - indicator_number - Which configured instance of the analyzer this indicator applies too.
 - status - Whether the indicator is hot, cold or neutral.


### PR DESCRIPTION
With this changes it is possible to use a template like this:
` template: "[{{analysis.config.candle_period}} / {{analysis.config.period_count}}] {{market}} {{indicator}} is {{status}}! ({{values}}) {{ '\n' -}}https://www.tradingview.com/symbols/{{market_from}}{{market_to}}/technicals/ {{ '\n' -}}https://bittrex.com/Market/Index?MarketName={{market_to}}-{{market_from}}{{ '\n' -}}{{ '\n' -}}"`

This will create


> [1h / 10] DASH/BTC momentum is cold! ({'momentum': '-0.00002000'}) 
> 
> https://www.tradingview.com/symbols/DASHBTC/technicals/ 
> 
> https://bittrex.com/Market/Index?MarketName=BTC-DASH
> 

only to better assemble the URLs
I like to be able to click the URLs directly