### PR TITLE
Aroon Oscillator indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ informants:
 
 The Aroon Oscillator is the difference between Aroon-Up and Aroon-Down. These two indicators are usually plotted together for easy comparison, but chartists can also view the difference between these two indicators with the Aroon Oscillator. This indicator fluctuates between -100 and +100 with zero as the middle line. An upward trend bias is present when the oscillator is positive, while a downward trend bias exists when the oscillator is negative. 
 
-The Aroon Oscillator is positive daily volume was above the (default)50-day moving average of volume = hot notification
-The Aroon Oscillator is negative daily volume was above the (default)50-day moving average of volume = cold notification
+The Aroon Oscillator is positive AND daily volume was above the (default)50-day moving average of volume = hot notification
+The Aroon Oscillator is negative AND daily volume was above the (default)50-day moving average of volume = cold notification
 
 
 Periods in example are the default values
@@ -154,6 +154,8 @@ indicators:
       signal:
         - aroon
       candle_period: 1d
+      hot: 0
+      cold: 0
 ```
 
 #### Klinger Oscillator - klinger_oscillator

--- a/README.md
+++ b/README.md
@@ -133,7 +133,28 @@ informants:
           candle_period: 4h
           period_count: 14
 ```
+#### Aroon Oscillator - aroon_oscillator
 
+The Aroon Oscillator is the difference between Aroon-Up and Aroon-Down. These two indicators are usually plotted together for easy comparison, but chartists can also view the difference between these two indicators with the Aroon Oscillator. This indicator fluctuates between -100 and +100 with zero as the middle line. An upward trend bias is present when the oscillator is positive, while a downward trend bias exists when the oscillator is negative. 
+
+The Aroon Oscillator is positive daily volume was above the (default)50-day moving average of volume = hot notification
+The Aroon Oscillator is negative daily volume was above the (default)50-day moving average of volume = cold notification
+
+
+Periods in example are the default values
+
+```
+indicators:
+  aroon_oscillator:
+    - enabled: true
+      alert_enabled: true
+      alert_frequency: always
+      sma_vol_period = 50
+      period_count = 25
+      signal:
+        - aroon
+      candle_period: 1d
+```
 
 #### Klinger Oscillator - klinger_oscillator
 

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -29,6 +29,7 @@ class StrategyAnalyzer():
         """
 
         dispatcher = {
+            'aroon_oscillator': aroon.oscillator.Aroon_oscillator().analyze,
             'adx': adx.Adx().analyze,
             'ichimoku': ichimoku.Ichimoku().analyze,
             'macd': macd.MACD().analyze,

--- a/app/analysis.py
+++ b/app/analysis.py
@@ -29,7 +29,7 @@ class StrategyAnalyzer():
         """
 
         dispatcher = {
-            'aroon_oscillator': aroon.oscillator.Aroon_oscillator().analyze,
+            'aroon_oscillator': aroon_oscillator.Aroon_oscillator().analyze,
             'adx': adx.Adx().analyze,
             'ichimoku': ichimoku.Ichimoku().analyze,
             'macd': macd.MACD().analyze,

--- a/app/analyzers/indicators/__init__.py
+++ b/app/analyzers/indicators/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    'aroon_oscillator',
     'adx',
     'ichimoku',
     'macd',

--- a/app/analyzers/indicators/aroon_oscillator.py
+++ b/app/analyzers/indicators/aroon_oscillator.py
@@ -10,7 +10,60 @@ from analyzers.utils import IndicatorUtils
 
 
 class Aroon_oscillator(IndicatorUtils):
-    def analyze(self, historical_data, signal=["adx"], period_count=14, hot_thresh=None, cold_thresh=None):
+    def analyze(self, historical_data, signal=["aroon"], sma_period=50, period_count=25, hot_thresh=None, cold_thresh=None):
+        """Performs an aroon oscillator analysis on the historical data
+
+        Args:
+            historical_data (list): A matrix of historical OHCLV data.
+            signal (list, optional): Defaults to aroon. The indicator
+                line to check hot/cold against.
+            period_count (int, optional): Defaults to 25.
+            sma_count (int, optional): Defaults to 50 (used of hot/cold check)
+            hot_thresh (float, optional): Defaults to None. The threshold at which this might be
+                good to purchase.
+            cold_thresh (float, optional): Defaults to None. The threshold at which this might be
+                good to sell.
+
+        Returns:
+            pandas.DataFrame: A dataframe containing the indicators and hot/cold values.
         """
-        """
-        pass
+        dataframe = self.convert_to_dataframe(historical_data)
+
+        aroon_columns = {
+            'aroon': [numpy.nan] * dataframe.index.shape[0],
+            'aroon_up': [numpy.nan] * dataframe.index.shape[0],
+            'aroon_down': [numpy.nan] * dataframe.index.shape[0]
+        }
+
+        aroon_values = pandas.DataFrame(aroon_columns,
+                                      index=dataframe.index
+                                      )
+
+        for index in range(0, dataframe.shape[0]-24):
+            id = dataframe.shape[0]-index
+            id_period = id - period_count
+            high_date = dataframe['high'].iloc[id_period:id].idxmax()
+            low_date = dataframe['low'].iloc[id_period:id].idxmin()
+
+            periods_since_high = id - dataframe.index.get_loc(high_date) - 1
+            periods_since_low = id - dataframe.index.get_loc(low_date) - 1
+            aroon_values['aroon_up'][id-1] = 100 * ((25 - periods_since_high) / 25)
+
+            aroon_values['aroon_down'][id-1] = 100 * ((25 - periods_since_low) / 25)
+
+        aroon_values['aroon'] = aroon_values['aroon_up'] - aroon_values['aroon_down']
+
+        aroon_values['is_hot'] = False
+        aroon_values['is_cold'] = False
+
+        aroon_values['sma_volume'] = df.dataframe.rolling(sma_period).mean()
+        aroon = aroon_values['aroon']
+        volume = dataframe[volume].iloc[-1]
+        volume_sma = aroon_values['sma_volume'].iloc[-1]
+
+        if aroon > hot_thresh and volume > volume_sma:
+            aroon_values['is_hot'].iloc[-1] = True
+        elif aroon <= cold_thresh and volume < volume_sma:
+            aroon_values['is_cold'].iloc[-1] = True
+
+        return aroon_values

--- a/app/analyzers/indicators/aroon_oscillator.py
+++ b/app/analyzers/indicators/aroon_oscillator.py
@@ -1,0 +1,16 @@
+
+"""
+Aroon Oscillator
+"""
+
+import pandas
+import numpy
+
+from analyzers.utils import IndicatorUtils
+
+
+class Aroon_oscillator(IndicatorUtils):
+    def analyze(self, historical_data, signal=["adx"], period_count=14, hot_thresh=None, cold_thresh=None):
+        """
+        """
+        pass

--- a/app/analyzers/indicators/aroon_oscillator.py
+++ b/app/analyzers/indicators/aroon_oscillator.py
@@ -10,7 +10,7 @@ from analyzers.utils import IndicatorUtils
 
 
 class Aroon_oscillator(IndicatorUtils):
-    def analyze(self, historical_data, signal=["aroon"], sma_vol_period, period_count=25, hot_thresh=None, cold_thresh=None):
+    def analyze(self, historical_data, sma_vol_period, period_count=25, signal=["aroon"], hot_thresh=None, cold_thresh=None):
         """Performs an aroon oscillator analysis on the historical data
 
         Args:
@@ -56,9 +56,9 @@ class Aroon_oscillator(IndicatorUtils):
         aroon_values['is_hot'] = False
         aroon_values['is_cold'] = False
 
-        aroon_values['sma_volume'] = df.dataframe.rolling(sma_vol_period).mean()
-        aroon = aroon_values['aroon']
-        volume = dataframe[volume].iloc[-1]
+        aroon_values['sma_volume'] = dataframe.volume.rolling(sma_vol_period).mean()
+        aroon = aroon_values['aroon'].iloc[-1]
+        volume = dataframe['volume'].iloc[-1]
         volume_sma = aroon_values['sma_volume'].iloc[-1]
 
         if aroon > hot_thresh and volume > volume_sma:

--- a/app/analyzers/indicators/aroon_oscillator.py
+++ b/app/analyzers/indicators/aroon_oscillator.py
@@ -63,7 +63,7 @@ class Aroon_oscillator(IndicatorUtils):
 
         if aroon > hot_thresh and volume > volume_sma:
             aroon_values['is_hot'].iloc[-1] = True
-        elif aroon <= cold_thresh and volume < volume_sma:
+        elif aroon <= cold_thresh and volume > volume_sma:
             aroon_values['is_cold'].iloc[-1] = True
 
         return aroon_values

--- a/app/analyzers/indicators/aroon_oscillator.py
+++ b/app/analyzers/indicators/aroon_oscillator.py
@@ -10,7 +10,7 @@ from analyzers.utils import IndicatorUtils
 
 
 class Aroon_oscillator(IndicatorUtils):
-    def analyze(self, historical_data, signal=["aroon"], sma_period=50, period_count=25, hot_thresh=None, cold_thresh=None):
+    def analyze(self, historical_data, signal=["aroon"], sma_vol_period, period_count=25, hot_thresh=None, cold_thresh=None):
         """Performs an aroon oscillator analysis on the historical data
 
         Args:
@@ -56,7 +56,7 @@ class Aroon_oscillator(IndicatorUtils):
         aroon_values['is_hot'] = False
         aroon_values['is_cold'] = False
 
-        aroon_values['sma_volume'] = df.dataframe.rolling(sma_period).mean()
+        aroon_values['sma_volume'] = df.dataframe.rolling(sma_vol_period).mean()
         aroon = aroon_values['aroon']
         volume = dataframe[volume].iloc[-1]
         volume_sma = aroon_values['sma_volume'].iloc[-1]

--- a/app/behaviour.py
+++ b/app/behaviour.py
@@ -240,6 +240,9 @@ class Behaviour():
                         analysis_args['kijunsen_period'] = indicator_conf['kijunsen_period'] if 'kijunsen_period' in indicator_conf else 60
                         analysis_args['senkou_span_b_period'] = indicator_conf['senkou_span_b_period'] if 'senkou_span_b_period' in indicator_conf else 120
 
+                    if indicator == 'aroon_oscillator':
+                        analysis_args['sma_vol_period'] = indicator_conf['sma_vol_period'] if 'sma_vol_period' in indicator_conf else 50
+
                     results[indicator].append({
                         'result': self._get_analysis_result(
                             indicator_dispatcher,


### PR DESCRIPTION
The Aroon Oscillator is the difference between Aroon-Up and Aroon-Down. These two indicators are usually plotted together for easy comparison, but chartists can also view the difference between these two indicators with the Aroon Oscillator. This indicator fluctuates between -100 and +100 with zero as the middle line. An upward trend bias is present when the oscillator is positive, while a downward trend bias exists when the oscillator is negative. 