### PR TITLE
datetime.timedelta fix for unsupported arguments (monts, years)

### DIFF
--- a/app/exchange.py
+++ b/app/exchange.py
@@ -88,6 +88,13 @@ class ExchangeInterface():
                 'y': 'years'
             }
 
+            if time_period == 'M':
+                time_period = 'w'
+                time_quantity = 4
+            elif time_period == 'Y':
+                time_period = 'w'
+                time_quantity = 48
+
             timedelta_args = { timedelta_values[time_period]: int(time_quantity) }
 
             start_date_delta = timedelta(**timedelta_args)


### PR DESCRIPTION
Fix for issue  [#390](https://github.com/CryptoSignal/crypto-signal/issues/390#issue-684973328)
