### PR TITLE
Add error handling for IndexError in _get_crossover_results

### DIFF
--- a/app/behaviour.py
+++ b/app/behaviour.py
@@ -247,8 +247,13 @@ class Behaviour():
                     self.logger.debug("%s is disabled, skipping.", crossover)
                     continue
 
-                key_indicator = new_result[crossover_conf['key_indicator_type']][crossover_conf['key_indicator']][crossover_conf['key_indicator_index']]
-                crossed_indicator = new_result[crossover_conf['crossed_indicator_type']][crossover_conf['crossed_indicator']][crossover_conf['crossed_indicator_index']]
+                # An earlier error in fetching get_historical_data can lead to a hard crash due to`IndexError`, as the indicators will fail to populate `new_result`
+                # In that case, this should be a no-op and will leave results unchanged.
+                try:
+                    key_indicator = new_result[crossover_conf['key_indicator_type']][crossover_conf['key_indicator']][crossover_conf['key_indicator_index']]
+                    crossed_indicator = new_result[crossover_conf['crossed_indicator_type']][crossover_conf['crossed_indicator']][crossover_conf['crossed_indicator_index']]
+                except IndexError:
+                    return results
 
                 dispatcher_args = {
                     'key_indicator': key_indicator['result'],
@@ -279,6 +284,7 @@ class Behaviour():
         """
 
         historical_data = list()
+
         try:
             historical_data = self.exchange_interface.get_historical_data(
                 market_pair,


### PR DESCRIPTION
**Bug Report:**
I was running the server and at some point received an Error when getting historical data from Binance.

This led the server to fully crash with the following:

```
enabled notifers: ['slack', 'stdout']
Starting default analyzer...
Found configured markets: ['BTC/USDT', 'ETH/BTC', 'XRP/BTC', 'ADA/BTC']
Using the following exchange(s): ['binance']
Beginning analysis of binance
Beginning analysis of ETH/BTC
Traceback (most recent call last):
  File "app.py", line 45, in <module>
    main()
  File "app.py", line 39, in main
    behaviour.run(settings['market_pairs'], settings['output_mode'])
  File "/app/behaviour.py", line 63, in run
    new_result = self._test_strategies(market_data, output_mode)
  File "/app/behaviour.py", line 98, in _test_strategies
    new_result[exchange][market_pair]
  File "/app/behaviour.py", line 250, in _get_crossover_results
    key_indicator = new_result[crossover_conf['key_indicator_type']][crossover_conf['key_indicator']][crossover_conf['key_indicator_index']]
IndexError: list index out of range
```

I've created my own branch that can replicate this easily:
[View the code here](https://github.com/Crizzooo/Crypto-Signal/commit/865a17fc9e27b314a74c4cb85736e9af678d2880)
 - `git clone https://github.com/Crizzooo/Crypto-Signal.git`
 - `git checkout replicate-index-error`
 - run `make build`
 - run `docker run --rm -v $PWD/config.yml:/app/config.yml shadowreaver/crypto-signal:master`
 - Should be ListIndex error on the first behaviour loop

To replicate on your own:
  - Create a `config.yml` that uses crossed_indicators, make Historical Data return an empty list as if the exchange fetch failed
  - Should be ListIndex error on the first behaviour loop

**Solution**

- Seems that when populating crossovers, the script is hardcoded to assume the indicators have correctly populated by index. When no data is present, the indicators are not populated, and `_get_crossover_results_` fails to grab the indicator by the config's `key_indicator_index`
- Wrap the setting of `key_indicator`, and `crossed_indicator` with a `Try/Except IndexError` and then perform a no-op by returning the unchanged `results` set


There might be a more graceful solution to skip the entire loop if we fail to fetch historical data, but I am unfamiliar with the ideals of this codebase. Just drawing attention to the problem and possible solution
