### PR TITLE
fix pandas indexing warning

### DIFF
--- a/app/analyzers/indicators/ma_crossover.py
+++ b/app/analyzers/indicators/ma_crossover.py
@@ -1,4 +1,4 @@
-""" Custom Indicator Increase In  Volume
+""" Custom Indicator Moving Average Crossover
 """
 
 import math
@@ -12,7 +12,7 @@ from analyzers.utils import IndicatorUtils
 class MACrossover(IndicatorUtils):
 
     def analyze(self, historical_data, signal=['close'], hot_thresh=None, cold_thresh=None, exponential=True, ma_fast=10, ma_slow=50):
-        """Performs an analysis about the increase in volumen on the historical data
+        """Performs an analysis about a crossover in 2 moving averages
 
         Args:
             historical_data (list): A matrix of historical OHCLV data.
@@ -45,7 +45,9 @@ class MACrossover(IndicatorUtils):
         ma_crossover['is_hot'] = False
         ma_crossover['is_cold'] = False
 
-        ma_crossover['is_hot'].iloc[-1] = previous_fast < previous_slow and current_fast > current_slow
-        ma_crossover['is_cold'].iloc[-1] = previous_fast > previous_slow and current_fast < current_slow
+        last_row = ma_crossover.iloc[-1].copy()
+        last_row['is_hot'] = previous_fast < previous_slow and current_fast > current_slow
+        last_row['is_cold'] = previous_fast > previous_slow and current_fast < current_slow
+        ma_crossover.iloc[-1] = last_row
 
         return ma_crossover


### PR DESCRIPTION
Maybe useful. I was getting a pandas warning "SettingWithCopyWarning: A value is trying to be set on a copy of a slice from a DataFrame" because 2 indexes are being used at the same time. This fixes it by copying the last row, altering it, then adding it back in.  