### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ build:
 	docker tag ${DOCKER_IMAGE_NAME}:${GIT_BRANCH} ${DOCKER_IMAGE_NAME}:latest
 
 run:
-	docker run -it --rm -v $PWD/config.yml:/app/config.yml ${DOCKER_IMAGE_NAME}
+	docker run -it --rm -v ${PWD}/config.yml:/app/config.yml ${DOCKER_IMAGE_NAME}


### PR DESCRIPTION
Fixed bug when running: make run on ubuntu machine.
    There was an error:
    docker: Error response from daemon: create WD/config.yml: "WD/config.yml" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
    
    So by wrapping PWD var into ${} fixed the problem.